### PR TITLE
Hotfix: bug fix at xf_cdot function in rk4.c

### DIFF
--- a/src/mqc/el_prop/rk4.c
+++ b/src/mqc/el_prop/rk4.c
@@ -114,7 +114,7 @@ static void xf_cdot(int nst, int nat, int nsp, int *l_coh, double wsigma,
     for(ist = 0; ist < nst; ist++){
         xfcdot[ist] = 0.0 + 0.0 * I;
         for(jst = 0; jst < nst; jst++){
-            xfcdot[ist] -= - rho[jst] * dec[jst][ist] * c[ist];
+            xfcdot[ist] -= rho[jst] * dec[jst][ist] * c[ist];
         }
     }
     free(rho);


### PR DESCRIPTION
Sign of the decoherence part of the time derivative of the coefficient fixed.