### PR TITLE
Set correct MM force when hop occurs

### DIFF
--- a/src/mm/tinker.py
+++ b/src/mm/tinker.py
@@ -473,16 +473,26 @@ class Tinker(MM_calculator):
             :param integer,list bo_list: List of BO states for BO calculation
             :param boolean calc_force_only: Logical to decide whether calculate force only
         """
+        if (self.scheme == "additive"):
+            # Read 'tinker.out.2' file
+            file_name = "tinker.out.2"
+            with open(file_name, "r") as f:
+                tinker_out2 = f.read()
+        elif (self.scheme == "subtractive"):
+            # Read 'tinker.out.12' file
+            file_name = "tinker.out.12"
+            with open(file_name, "r") as f:
+                tinker_out12 = f.read()
+            # Read 'tinker.out.1' file
+            file_name = "tinker.out.1"
+            with open(file_name, "r") as f:
+                tinker_out1 = f.read()
+
         if (not calc_force_only):
             # Energy; initialize the energy at MM level
             mm_energy = 0.
 
             if (self.scheme == "additive"):
-
-                # Read 'tinker.out.2' file
-                file_name = "tinker.out.2"
-                with open(file_name, "r") as f:
-                    tinker_out2 = f.read()
 
                 tmp_e = 'Total Potential Energy :' + '\s+([-]*\S+)\s+' + 'Kcal/mole'
                 energy = re.findall(tmp_e, tinker_out2)
@@ -491,20 +501,10 @@ class Tinker(MM_calculator):
 
             elif (self.scheme == "subtractive"):
 
-                # Read 'tinker.out.12' file
-                file_name = "tinker.out.12"
-                with open(file_name, "r") as f:
-                    tinker_out12 = f.read()
-
                 tmp_e = 'Total Potential Energy :' + '\s+([-]*\S+)\s+' + 'Kcal/mole'
                 energy = re.findall(tmp_e, tinker_out12)
                 energy = np.array(energy, dtype=np.float64)
                 mm_energy += energy[0]
-
-                # Read 'tinker.out.1' file
-                file_name = "tinker.out.1"
-                with open(file_name, "r") as f:
-                    tinker_out1 = f.read()
 
                 tmp_e = 'Total Potential Energy :' + '\s+([-]*\S+)\s+' + 'Kcal/mole'
                 energy = re.findall(tmp_e, tinker_out1)

--- a/src/mqc/sh.py
+++ b/src/mqc/sh.py
@@ -188,8 +188,9 @@ class SH(MQC):
                 if (self.mol.ekin_qm > eps):
                     self.correct_dec_edc()
 
-            if (qm.re_calc and self.l_hop):
-                qm.get_data(self.mol, base_dir, bo_list, self.dt, istep, calc_force_only=True)
+            if (self.l_hop):
+                if (qm.re_calc):
+                    qm.get_data(self.mol, base_dir, bo_list, self.dt, istep, calc_force_only=True)
                 if (self.mol.l_qmmm and mm != None):
                     mm.get_data(self.mol, base_dir, bo_list, istep, calc_force_only=True)
 


### PR DESCRIPTION
In current version, PyUNIxMD does not obtain correct MM force when hop occurs. It affects energy conservation at next step.