### PR TITLE
Fix DFTB/SSR interfacing for QM and QM/MM calculations

### DIFF
--- a/src/mm/tinker.py
+++ b/src/mm/tinker.py
@@ -311,7 +311,11 @@ class Tinker(MM_calculator):
 
         # To avoid double counting, consider only charge-charge interactions between MM atoms
         if (self.embedding == "electrostatic"):
+            # Save atom types for QM atoms
+            qm_atom_type = set(self.atom_type[0:molecule.nat_qm])
+            # Save QM atom types existing in 'tinker.key' file
             tmp_atom_type = []
+
             file_be = open('tinker.key', 'r')
             file_af = open('tmp.key', 'w')
             for line in file_be:
@@ -324,7 +328,7 @@ class Tinker(MM_calculator):
                                 ind_charge = col
                             col += 1
                         # Set charge to zero for QM atoms in electrostatic embedding
-                        if (int(field[ind_charge + 1]) in set(self.atom_type)):
+                        if (int(field[ind_charge + 1]) in qm_atom_type):
                             tmp_atom_type.append(int(field[ind_charge + 1]))
                             line = f"charge {int(field[ind_charge + 1])} 0.0\n"
                             file_af.write(line)
@@ -335,7 +339,7 @@ class Tinker(MM_calculator):
                     # Write lines without 'charge' word
                     file_af.write(line)
             # Set charge to zero for remaining QM atoms
-            for itype in set(self.atom_type):
+            for itype in qm_atom_type:
                 if (not itype in tmp_atom_type):
                     line = f"charge {itype} 0.0\n"
                     file_af.write(line)

--- a/src/mqc/mqc.py
+++ b/src/mqc/mqc.py
@@ -120,9 +120,9 @@ class MQC(object):
         if (self.mol.l_qmmm and mm != None):
             self.check_qmmm(qm, mm)
 
-        # Exception for CTMQC with QM/MM
-        if ((self.md_type == "CT") and (mm != None)):
-            error_message = "QM/MM calculation is not compatible with CTMQC now!"
+        # Exception for CTMQC/Ehrenfest with QM/MM
+        if ((self.md_type in ["CT", "Eh"]) and (mm != None)):
+            error_message = "QM/MM calculation is not compatible with CTMQC or Ehrenfest now!"
             error_vars = f"mm = {mm}"
             raise NotImplementedError (f"( {self.md_type}.{call_name()} ) {error_message} ( {error_vars} )")
 

--- a/src/qm/dftbplus/dftb.py
+++ b/src/qm/dftbplus/dftb.py
@@ -477,6 +477,8 @@ class DFTB(DFTBplus):
             parser_version = 7
         elif (self.version == "20.1"):
             parser_version = 8
+        elif (self.version == "21.1"):
+            parser_version = 9
 
         input_parseroptions = textwrap.dedent(f"""\
         ParserOptions = {{

--- a/src/qm/dftbplus/dftbplus.py
+++ b/src/qm/dftbplus/dftbplus.py
@@ -29,7 +29,7 @@ class DFTBplus(QM_calculator):
 
         # Environmental variable setting for Python scripts such as xyz2gen used in DFTB+
         if (isinstance(self.version, str)):
-            if (self.version in ["19.1", "20.1"]):
+            if (self.version in ["19.1", "20.1", "21.1"]):
                 self.qm_path = os.path.join(self.install_path, "bin")
                 # Note that the Python version can be changed according to the users setting
                 lib_dir = os.path.join(self.install_path, "lib/python3.6/site-packages")

--- a/src/qm/dftbplus/ssr.py
+++ b/src/qm/dftbplus/ssr.py
@@ -455,6 +455,8 @@ class SSR(DFTBplus):
         # Copy the output file to 'qm_log' directory
         tmp_dir = os.path.join(base_dir, "qm_log")
         if (os.path.exists(tmp_dir)):
+            detailed_out_step = f"detailed.out.{istep + 1}.{bo_list[0]}"
+            shutil.copy("detailed.out", os.path.join(tmp_dir, detailed_out_step))
             log_step = f"log.{istep + 1}.{bo_list[0]}"
             shutil.copy("log", os.path.join(tmp_dir, log_step))
 

--- a/src/qm/dftbplus/ssr.py
+++ b/src/qm/dftbplus/ssr.py
@@ -515,12 +515,13 @@ class SSR(DFTBplus):
 
         # NAC
         if (not calc_force_only and self.nac == "Yes"):
+            tmp_c = 'non-adiabatic coupling' + '\n\s+([-]*\S+)\s+([-]*\S+)\s+([-]*\S+)' * molecule.nat_qm
+            tmp_c = re.findall(tmp_c, log_out)
+
             kst = 0
             for ist in range(molecule.nst):
                 for jst in range(ist + 1, molecule.nst):
-                    tmp_c = 'non-adiabatic coupling' + '\n\s+([-]*\S+)\s+([-]*\S+)\s+([-]*\S+)' * molecule.nat_qm
-                    nac = re.findall(tmp_c, log_out)
-                    nac = np.array(nac[kst], dtype=np.float64)
+                    nac = np.array(tmp_c[kst], dtype=np.float64)
                     nac = nac.reshape(molecule.nat_qm, 3, order='C')
                     molecule.nac[ist, jst] = nac
                     molecule.nac[jst, ist] = - nac

--- a/src/qm/dftbplus/ssr.py
+++ b/src/qm/dftbplus/ssr.py
@@ -100,6 +100,11 @@ class SSR(DFTBplus):
             error_vars = f"embedding = {self.embedding}"
             raise ValueError (f"( {self.qm_method}.{call_name()} ) {error_message} ( {error_vars} )")
 
+        if (not molecule.l_qmmm and self.embedding in ["mechanical", "electrostatic"]):
+            error_message = "Set logical for QM/MM to True for QM/MM calculation!"
+            error_vars = f"Molecule.l_qmmm = {molecule.l_qmmm}"
+            raise ValueError (f"( {self.qm_method}.{call_name()} ) {error_message} ( {error_vars} )")
+
         self.l_periodic = l_periodic
         self.a_axis = np.copy(cell_length[0:3])
         self.b_axis = np.copy(cell_length[3:6])

--- a/src/qm/dftbplus/ssr.py
+++ b/src/qm/dftbplus/ssr.py
@@ -486,46 +486,33 @@ class SSR(DFTBplus):
         # Force
         if (self.nac == "Yes"):
             # SHXF, SH, Eh : SSR state
-            if (molecule.l_qmmm):
-                for ist in range(molecule.nst):
-                    tmp_g = f' {ist + 1} st state \(SSR\)' + '\n\s+([-]*\S+)\s+([-]*\S+)\s+([-]*\S+)' * molecule.nat_qm
-                    grad = re.findall(tmp_g, log_out)
-                    grad = np.array(grad[0], dtype=np.float64)
-                    grad = grad.reshape(molecule.nat_qm, 3, order='C')
-                    molecule.states[ist].force[0:molecule.nat_qm] = - grad
-                    if (self.embedding == "electrostatic"):
-                        tmp_f = 'Forces on external charges' + '\n\s+([-]*\S+)\s+([-]*\S+)\s+([-]*\S+)' * molecule.nat_mm
-                        force = re.findall(tmp_f, detailed_out)
-                        force = np.array(force[0], dtype=np.float64)
-                        force = force.reshape(molecule.nat_mm, 3, order='C')
-                        molecule.states[ist].force[molecule.nat_qm:molecule.nat] = force
-            else:
-                for ist in range(molecule.nst):
-                    tmp_g = f' {ist + 1} st state \(SSR\)' + '\n\s+([-]*\S+)\s+([-]*\S+)\s+([-]*\S+)' * molecule.nat_qm
-                    grad = re.findall(tmp_g, log_out)
-                    grad = np.array(grad[0], dtype=np.float64)
-                    grad = grad.reshape(molecule.nat_qm, 3, order='C')
-                    molecule.states[ist].force = - np.copy(grad)
-        else:
-            # BOMD : SSR state, SA-REKS state or single-state REKS
-            if (molecule.l_qmmm):
-                tmp_g = f' {bo_list[0] + 1} state \(\w+[-]*\w+\)' + '\n\s+([-]*\S+)\s+([-]*\S+)\s+([-]*\S+)' * molecule.nat_qm
-                grad = re.findall(tmp_g, log_out)
-                grad = np.array(grad[0], dtype=np.float64)
+            tmp_g = f' state \(SSR\)' + '\n\s+([-]*\S+)\s+([-]*\S+)\s+([-]*\S+)' * molecule.nat_qm
+            tmp_g = re.findall(tmp_g, log_out)
+            for ist in range(molecule.nst):
+                grad = np.array(tmp_g[ist], dtype=np.float64)
                 grad = grad.reshape(molecule.nat_qm, 3, order='C')
-                molecule.states[bo_list[0]].force[0:molecule.nat_qm] = - grad
-                if (self.embedding == "electrostatic"):
+                molecule.states[ist].force[0:molecule.nat_qm] = - np.copy(grad)
+                # TODO : point charge gradient may be modified
+                if (molecule.l_qmmm and self.embedding == "electrostatic"):
                     tmp_f = 'Forces on external charges' + '\n\s+([-]*\S+)\s+([-]*\S+)\s+([-]*\S+)' * molecule.nat_mm
                     force = re.findall(tmp_f, detailed_out)
                     force = np.array(force[0], dtype=np.float64)
                     force = force.reshape(molecule.nat_mm, 3, order='C')
-                    molecule.states[bo_list[0]].force[molecule.nat_qm:molecule.nat] = force
-            else:
-                tmp_g = f' {bo_list[0] + 1} state \(\w+[-]*\w+\)' + '\n\s+([-]*\S+)\s+([-]*\S+)\s+([-]*\S+)' * molecule.nat_qm
-                grad = re.findall(tmp_g, log_out)
-                grad = np.array(grad[0], dtype=np.float64)
-                grad = grad.reshape(molecule.nat_qm, 3, order='C')
-                molecule.states[bo_list[0]].force = - np.copy(grad)
+                    molecule.states[ist].force[molecule.nat_qm:molecule.nat] = force
+        else:
+            # BOMD : SSR state, SA-REKS state or single-state REKS
+            tmp_g = f' {bo_list[0] + 1} state \(\w+[-]*\w+\)' + '\n\s+([-]*\S+)\s+([-]*\S+)\s+([-]*\S+)' * molecule.nat_qm
+            tmp_g = re.findall(tmp_g, log_out)
+            grad = np.array(tmp_g[0], dtype=np.float64)
+            grad = grad.reshape(molecule.nat_qm, 3, order='C')
+            molecule.states[bo_list[0]].force[0:molecule.nat_qm] = - np.copy(grad)
+            # TODO : point charge gradient may be modified
+            if (molecule.l_qmmm and self.embedding == "electrostatic"):
+                tmp_f = 'Forces on external charges' + '\n\s+([-]*\S+)\s+([-]*\S+)\s+([-]*\S+)' * molecule.nat_mm
+                force = re.findall(tmp_f, detailed_out)
+                force = np.array(force[0], dtype=np.float64)
+                force = force.reshape(molecule.nat_mm, 3, order='C')
+                molecule.states[bo_list[0]].force[molecule.nat_qm:molecule.nat] = force
 
         # NAC
         if (self.nac == "Yes"):

--- a/src/qm/dftbplus/ssr.py
+++ b/src/qm/dftbplus/ssr.py
@@ -424,6 +424,8 @@ class SSR(DFTBplus):
             raise ValueError (f"( {self.qm_method}.{call_name()} ) {error_message} ( {error_vars} )")
         elif (self.version == "20.1"):
             parser_version = 8
+        elif (self.version == "21.1"):
+            parser_version = 9
 
         input_parseroptions = textwrap.dedent(f"""\
         ParserOptions = {{


### PR DESCRIPTION
- Now, DFTB+ version 21.1 is available.
- Simplified reading of gradients for QM and QM/MM atoms.
- qm.re_calc is changed to True (restart and nac is modified).
- Fix a bug for reading of gradients for point charges. Previous code does not calculate correct gradients when hop occurs.
- In Tinker interfacing, correct QM atom types are now used.
- QM/MM calculation is not compatible with Ehrenfest dynamics.