### PR TITLE
Commenting out of renormalization section

### DIFF
--- a/src/mqc/el_prop/rk4.c
+++ b/src/mqc/el_prop/rk4.c
@@ -100,8 +100,8 @@ static void rk4_coef(int nst, int nesteps, double dt, double *energy, double *en
             coef_new[ist] = coef[ist] + variation[ist];
         }
         /*
-        TODO : Is this part necessary?
-        Renormalize the coefficients
+        //TODO : Is this part necessary?
+        //Renormalize the coefficients
         norm = dot(nst, coef_new, coef_new);
         for(ist = 0; ist < nst; ist++){
             coef_new[ist] /= sqrt(norm);

--- a/src/mqc/el_prop/rk4.c
+++ b/src/mqc/el_prop/rk4.c
@@ -99,15 +99,15 @@ static void rk4_coef(int nst, int nesteps, double dt, double *energy, double *en
                 * k3[ist] + k4[ist]) / 6.0;
             coef_new[ist] = coef[ist] + variation[ist];
         }
-
-        // TODO : Is this part necessary?
-        // Renormalize the coefficients
+        /*
+        TODO : Is this part necessary?
+        Renormalize the coefficients
         norm = dot(nst, coef_new, coef_new);
         for(ist = 0; ist < nst; ist++){
             coef_new[ist] /= sqrt(norm);
             coef[ist] = coef_new[ist];
         }
-
+	*/
     }
 
     /* 


### PR DESCRIPTION
I have commented out the renormalization step of rk4.c file with /* and */.
Renormalization seemed redundant as norm conservation is in principle guaranteed.