### PR TITLE
Fix some bugs and conventions in MQC, MQC_QED, and CPA

### DIFF
--- a/src/cpa/cpa.py
+++ b/src/cpa/cpa.py
@@ -276,8 +276,8 @@ class CPA(object):
         tmp = f'{"#":5s}Non-Adiabatic Coupling Matrix Elements: off-diagonal'
         typewriter(tmp, unixmd_dir, "NACME", "w")
 
-        # DOTPOPNAC file header
         if (self.verbosity >= 1):
+            # DOTPOPNAC file header
             tmp = f'{"#":5s} Time-derivative Density Matrix by NAC: population; see the manual for detail orders'
             typewriter(tmp, unixmd_dir, "DOTPOPNAC", "w")
 

--- a/src/cpa/cpa.py
+++ b/src/cpa/cpa.py
@@ -74,10 +74,9 @@ class CPA(object):
         # Initialize coefficients and densities
         self.mol.get_coefficient(init_coef, self.istate)
 
-    def run_init(self, qm, mm, output_dir):
+    def run_init(self, mm, output_dir):
         """ Initialize molecular dynamics with classical path approximation
 
-            :param object qm: QM object containing on-the-fly calculation information
             :param object mm: MM object containing MM calculation information
             :param string output_dir: Location of input directory
         """
@@ -89,7 +88,7 @@ class CPA(object):
 
         # Check compatibility of variables for QM and MM calculation
         if ((self.mol.l_qmmm and mm == None) or (not self.mol.l_qmmm and mm != None)):
-            error_message = "Both logical for QM/MM and MM object is necessary!"
+            error_message = "Both logicals for QM/MM and MM object are necessary!"
             error_vars = f"Molecule.l_qmmm = {self.mol.l_qmmm}, mm = {mm}"
             raise ValueError (f"( {self.md_type}.{call_name()} ) {error_message} ( {error_vars} )")
 

--- a/src/cpa/sh.py
+++ b/src/cpa/sh.py
@@ -2,9 +2,8 @@ from __future__ import division
 from lib.libmqc import el_run
 from cpa.cpa import CPA
 from misc import eps, au_to_K, call_name, typewriter
-import random, os, shutil, textwrap
+import random, textwrap
 import numpy as np
-import pickle
 
 class SH(CPA):
     """ Class for surface hopping dynamics with classical path approximation (CPA)
@@ -73,7 +72,7 @@ class SH(CPA):
         qm.calc_coupling = True
         qm.calc_tdp = False
         qm.calc_tdp_grad = False
-        base_dir, unixmd_dir = self.run_init(qm, mm, output_dir)
+        base_dir, unixmd_dir = self.run_init(mm, output_dir)
         bo_list = [self.rstate]
         self.print_init(traj, qm, mm)
 
@@ -97,7 +96,7 @@ class SH(CPA):
         self.evaluate_hop(bo_list)
 
         if (self.dec_correction == "idc"):
-            if (self.l_hop):
+            if (self.l_hop or self.l_reject):
                 self.correct_dec_idc()
         elif (self.dec_correction == "edc"):
             # If kinetic is 0, coefficient/density matrix are update into itself
@@ -118,6 +117,8 @@ class SH(CPA):
 
             self.mol.backup_bo(qm.calc_coupling)
             self.mol.reset_bo(qm.calc_coupling)
+            # Although a MM object is provided for QM/MM dynamics with CPA in running script,
+            # QM object already has the information obtained from QM/MM dynamics, so mm.get_data is not needed
             qm.get_data(self.mol, base_dir, bo_list, self.dt, istep, calc_force_only=False, traj=traj)
 
             self.cl_update_velocity(traj, istep)
@@ -129,7 +130,7 @@ class SH(CPA):
             self.evaluate_hop(bo_list)
 
             if (self.dec_correction == "idc"):
-                if (self.l_hop):
+                if (self.l_hop or self.l_reject):
                     self.correct_dec_idc()
             elif (self.dec_correction == "edc"):
                 # If kinetic is 0, coefficient/density matrix are update into itself

--- a/src/cpa/sh.py
+++ b/src/cpa/sh.py
@@ -324,8 +324,8 @@ class SH(CPA):
             :param string unixmd_dir: PyUNIxMD directory
             :param integer istep: Current MD step
         """
-        # Write NAC term in DOTPOPNAC
         if (self.verbosity >= 1):
+            # Write NAC term in DOTPOPNAC
             tmp = f'{istep + 1:9d}' + "".join([f'{pop:15.8f}' for pop in self.dotpopnac])
             typewriter(tmp, unixmd_dir, "DOTPOPNAC", "a")
 

--- a/src/cpa/shxf.py
+++ b/src/cpa/shxf.py
@@ -2,9 +2,8 @@ from __future__ import division
 from lib.libmqcxf import el_run
 from cpa.cpa import CPA
 from misc import eps, au_to_K, au_to_A, call_name, typewriter
-import random, os, shutil, textwrap
+import random, textwrap
 import numpy as np
-import pickle
 
 class Auxiliary_Molecule(object):
     """ Class for auxiliary molecule that is used for the calculation of decoherence term
@@ -134,7 +133,7 @@ class SHXF(CPA):
         qm.calc_coupling = True
         qm.calc_tdp = False
         qm.calc_tdp_grad = False
-        base_dir, unixmd_dir = self.run_init(qm, mm, output_dir)
+        base_dir, unixmd_dir = self.run_init(mm, output_dir)
         bo_list = [self.rstate]
         self.print_init(traj, qm, mm)
 
@@ -182,6 +181,8 @@ class SHXF(CPA):
 
             self.mol.backup_bo(qm.calc_coupling)
             self.mol.reset_bo(qm.calc_coupling)
+            # Although a MM object is provided for QM/MM dynamics with CPA in running script,
+            # QM object already has the information obtained from QM/MM dynamics, so mm.get_data is not needed
             qm.get_data(self.mol, base_dir, bo_list, self.dt, istep, calc_force_only=False, traj=traj)
 
             self.cl_update_velocity(traj, istep)

--- a/src/mqc/ct.py
+++ b/src/mqc/ct.py
@@ -120,7 +120,7 @@ class CT(MQC):
         qm.calc_tdp = False
         qm.calc_tdp_grad = False
         abs_path_output_dir = os.path.join(os.getcwd(), output_dir)
-        base_dirs, unixmd_dirs, traj_bin_dirs, qm_log_dirs, mm_log_dirs = \
+        base_dirs, unixmd_dirs, samp_bin_dirs, qm_log_dirs, mm_log_dirs = \
             self.run_init(qm, mm, output_dir, False, False, l_save_qm_log, l_save_mm_log, \
             l_save_scr, restart)
         bo_list = [ist for ist in range(self.nst)]

--- a/src/mqc/eh.py
+++ b/src/mqc/eh.py
@@ -173,8 +173,8 @@ class Eh(MQC):
             :param string unixmd_dir: PyUNIxMD directory
             :param integer istep: Current MD step
         """
-        # Write NAC term in DOTPOPNAC
         if (self.verbosity >= 1):
+            # Write NAC term in DOTPOPNAC
             tmp = f'{istep + 1:9d}' + "".join([f'{pop:15.8f}' for pop in self.dotpopnac])
             typewriter(tmp, unixmd_dir, "DOTPOPNAC", "a")
 

--- a/src/mqc/eh.py
+++ b/src/mqc/eh.py
@@ -50,7 +50,7 @@ class Eh(MQC):
         qm.calc_coupling = True
         qm.calc_tdp = False
         qm.calc_tdp_grad = False
-        base_dir, unixmd_dir, traj_bin_dir, qm_log_dir, mm_log_dir = \
+        base_dir, unixmd_dir, samp_bin_dir, qm_log_dir, mm_log_dir = \
             self.run_init(qm, mm, output_dir, False, False, l_save_qm_log, l_save_mm_log, \
             l_save_scr, restart)
         bo_list = [ist for ist in range(self.mol.nst)]

--- a/src/mqc/ehxf.py
+++ b/src/mqc/ehxf.py
@@ -121,7 +121,7 @@ class EhXF(MQC):
         self.event = {"HOP": [], "DECO": []}
 
     def run(self, qm, mm=None, output_dir="./", l_save_qm_log=False, l_save_mm_log=False, l_save_scr=True, restart=None):
-        """ Run MQC dynamics according to decoherence-induced Ehrenfest dynamics
+        """ Run MQC dynamics according to EhXF dynamics
 
             :param object qm: QM object containing on-the-fly calculation information
             :param object mm: MM object containing MM calculation information
@@ -135,7 +135,7 @@ class EhXF(MQC):
         qm.calc_coupling = True
         qm.calc_tdp = False
         qm.calc_tdp_grad = False
-        base_dir, unixmd_dir, traj_bin_dir, qm_log_dir, mm_log_dir = \
+        base_dir, unixmd_dir, samp_bin_dir, qm_log_dir, mm_log_dir = \
             self.run_init(qm, mm, output_dir, False, False, l_save_qm_log, l_save_mm_log, \
             l_save_scr, restart)
         bo_list = [self.rstate]

--- a/src/mqc/mqc.py
+++ b/src/mqc/mqc.py
@@ -121,8 +121,8 @@ class MQC(object):
                 raise ValueError (f"( {self.md_type}.{call_name()} ) {error_message} ( {error_vars} )")
 
         # Check compatibility for nonadiabatic coupling calculation in BOMD
-        if (self.md_type == "BOMD"):
-            if (l_coupling and not self.mol.l_nacme):
+        if (self.md_type == "BOMD" and l_coupling):
+            if (not self.mol.l_nacme):
                 if (not self.l_adj_nac):
                     error_message = "The phase of nonadiabatic couplings must be aligned!"
                     error_vars = f"l_adj_nac = {self.l_adj_nac}"

--- a/src/mqc/mqc.py
+++ b/src/mqc/mqc.py
@@ -130,7 +130,7 @@ class MQC(object):
 
         # Check compatibility of variables for QM and MM calculation
         if ((self.mol.l_qmmm and mm == None) or (not self.mol.l_qmmm and mm != None)):
-            error_message = "Both logical for QM/MM and MM object is necessary!"
+            error_message = "Both logicals for QM/MM and MM object are necessary!"
             error_vars = f"Molecule.l_qmmm = {self.mol.l_qmmm}, mm = {mm}"
             raise ValueError (f"( {self.md_type}.{call_name()} ) {error_message} ( {error_vars} )")
         if (self.mol.l_qmmm and mm != None):

--- a/src/mqc/sh.py
+++ b/src/mqc/sh.py
@@ -106,7 +106,7 @@ class SH(MQC):
         qm.calc_coupling = True
         qm.calc_tdp = False
         qm.calc_tdp_grad = False
-        base_dir, unixmd_dir, traj_bin_dir, qm_log_dir, mm_log_dir = \
+        base_dir, unixmd_dir, samp_bin_dir, qm_log_dir, mm_log_dir = \
             self.run_init(qm, mm, output_dir, False, False, l_save_qm_log, l_save_mm_log, \
             l_save_scr, restart)
         bo_list = [self.rstate]

--- a/src/mqc/sh.py
+++ b/src/mqc/sh.py
@@ -469,8 +469,8 @@ class SH(MQC):
             :param string unixmd_dir: PyUNIxMD directory
             :param integer istep: Current MD step
         """
-        # Write NAC term in DOTPOPNAC
         if (self.verbosity >= 1):
+            # Write NAC term in DOTPOPNAC
             tmp = f'{istep + 1:9d}' + "".join([f'{pop:15.8f}' for pop in self.dotpopnac])
             typewriter(tmp, unixmd_dir, "DOTPOPNAC", "a")
 

--- a/src/mqc/shxf.py
+++ b/src/mqc/shxf.py
@@ -155,7 +155,7 @@ class SHXF(MQC):
         self.event = {"HOP": [], "DECO": []}
 
     def run(self, qm, mm=None, output_dir="./", l_save_qm_log=False, l_save_mm_log=False, l_save_scr=True, restart=None):
-        """ Run MQC dynamics according to decoherence-induced surface hopping dynamics
+        """ Run MQC dynamics according to SHXF dynamics
 
             :param object qm: QM object containing on-the-fly calculation information
             :param object mm: MM object containing MM calculation information
@@ -169,7 +169,7 @@ class SHXF(MQC):
         qm.calc_coupling = True
         qm.calc_tdp = False
         qm.calc_tdp_grad = False
-        base_dir, unixmd_dir, traj_bin_dir, qm_log_dir, mm_log_dir = \
+        base_dir, unixmd_dir, samp_bin_dir, qm_log_dir, mm_log_dir = \
             self.run_init(qm, mm, output_dir, False, False, l_save_qm_log, l_save_mm_log, \
             l_save_scr, restart)
         bo_list = [self.rstate]

--- a/src/mqc_qed/bomd.py
+++ b/src/mqc_qed/bomd.py
@@ -128,6 +128,7 @@ class BOMD(MQC_QED):
 
             if ((istep + 1) % self.out_freq == 0):
                 self.write_md_output(unixmd_dir, istep)
+            if ((istep + 1) % self.out_freq == 0 or len(self.event["HOP"]) > 0):
                 self.print_step(istep)
             if (istep == self.nsteps - 1):
                 self.write_final_xyz(unixmd_dir, istep)

--- a/src/mqc_qed/mqc.py
+++ b/src/mqc_qed/mqc.py
@@ -66,7 +66,7 @@ class MQC_QED(object):
             raise ValueError (f"( {self.md_type}.{call_name()} ) {error_message} ( {error_vars} )")
 
         if not (self.elec_object in [None, "coefficient"]):
-            error_message = "Only coefficient object is available for QED calculation!"
+            error_message = "Only coefficient object is available for MQC_QED!"
             error_vars = f"elec_object = {self.elec_object}"
             raise ValueError (f"( {self.md_type}.{call_name()} ) {error_message} ( {error_vars} )")
 
@@ -135,7 +135,7 @@ class MQC_QED(object):
 
         # Check compatibility of variables for QM and MM calculation
         if ((self.pol.l_qmmm and mm == None) or (not self.pol.l_qmmm and mm != None)):
-            error_message = "Both logical for QM/MM and MM object is necessary!"
+            error_message = "Both logicals for QM/MM and MM object are necessary!"
             error_vars = f"Polariton.l_qmmm = {self.pol.l_qmmm}, mm = {mm}"
             raise ValueError (f"( {self.md_type}.{call_name()} ) {error_message} ( {error_vars} )")
         if (self.pol.l_qmmm and mm != None):

--- a/src/mqc_qed/mqc.py
+++ b/src/mqc_qed/mqc.py
@@ -455,13 +455,17 @@ class MQC_QED(object):
                     typewriter(tmp, unixmd_dir, "QEDCOHD", "w")
 
             # PNACME file header
-            tmp = f'{"#":5s}Non-Adiabatic Coupling Matrix Elements: off-diagonal'
+            tmp = f'{"#":5s}Polaritonic Non-Adiabatic Coupling Matrix Elements: off-diagonal'
             typewriter(tmp, unixmd_dir, "PNACME", "w")
 
-            # DOTPOPNACD file header
             if (self.verbosity >= 1):
+                # DOTPOPNACD file header
                 tmp = f'{"#":5s} Time-derivative Density Matrix by NAC: population; see the manual for detail orders'
                 typewriter(tmp, unixmd_dir, "DOTPOPNACD", "w")
+
+                # NACME file header
+                tmp = f'{"#":5s}Non-Adiabatic Coupling Matrix Elements: off-diagonal'
+                typewriter(tmp, unixmd_dir, "NACME", "w")
 
         # file header for SH-based methods
         if (self.md_type in ["SH", "SHXF"]):
@@ -524,8 +528,14 @@ class MQC_QED(object):
                 for ist in range(self.pol.pst) for jst in range(ist + 1, self.pol.pst)])
             typewriter(tmp, unixmd_dir, "PNACME", "a")
 
-            # Write PNACV file
+            if (self.verbosity >= 1):
+                # Write NACME file
+                tmp = f'{istep + 1:10d}' + "".join([f'{self.pol.nacme[ist, jst]:15.8f}' \
+                    for ist in range(self.pol.nst) for jst in range(ist + 1, self.pol.nst)])
+                typewriter(tmp, unixmd_dir, "NACME", "a")
+
             if (not self.pol.l_pnacme and self.verbosity >= 2):
+                # Write PNACV file
                 for ist in range(self.pol.pst):
                     for jst in range(ist + 1, self.pol.pst):
                         tmp = f'{self.pol.nat_qm:6d}\n{"":2s}Step:{istep + 1:6d}{"":12s}PNACV' + \

--- a/src/mqc_qed/mqc.py
+++ b/src/mqc_qed/mqc.py
@@ -454,7 +454,7 @@ class MQC_QED(object):
                     tmp = f'{"#":5s} Density Matrix: coherence Re-Im; see the manual for detail orders'
                     typewriter(tmp, unixmd_dir, "QEDCOHD", "w")
 
-            # NACME file header
+            # PNACME file header
             tmp = f'{"#":5s}Non-Adiabatic Coupling Matrix Elements: off-diagonal'
             typewriter(tmp, unixmd_dir, "PNACME", "w")
 

--- a/src/mqc_qed/sh.py
+++ b/src/mqc_qed/sh.py
@@ -522,8 +522,8 @@ class SH(MQC_QED):
             :param string unixmd_dir: PyUNIxMD directory
             :param integer istep: Current MD step
         """
-        # Write NAC term in DOTPOPNACD
         if (self.verbosity >= 1):
+            # Write NAC term in DOTPOPNACD
             tmp = f'{istep + 1:9d}' + "".join([f'{pop:15.8f}' for pop in self.dotpopnac_d])
             typewriter(tmp, unixmd_dir, "DOTPOPNACD", "a")
 

--- a/src/mqc_qed/shxf.py
+++ b/src/mqc_qed/shxf.py
@@ -25,7 +25,7 @@ class Auxiliary_Molecule(object):
 
 
 class SHXF(MQC_QED):
-    """ Class for DISH-XF dynamics coupled to confined cavity mode
+    """ Class for SHXF dynamics coupled to confined cavity mode
 
         :param object polariton: Polariton object
         :param object thermostat: Thermostat object
@@ -147,7 +147,7 @@ class SHXF(MQC_QED):
 
     def run(self, qed, qm, mm=None, output_dir="./", l_save_qed_log=False, l_save_qm_log=False, \
         l_save_mm_log=False, l_save_scr=True, restart=None):
-        """ Run MQC dynamics according to decoherence-induced surface hopping dynamics
+        """ Run MQC dynamics according to SHXF dynamics
 
             :param object qed: QED object containing cavity-molecule interaction
             :param object qm: QM object containing on-the-fly calculation information

--- a/src/mqc_qed/shxf.py
+++ b/src/mqc_qed/shxf.py
@@ -197,6 +197,7 @@ class SHXF(MQC_QED):
             self.hop_prob(qed)
             self.hop_check(pol_list)
             self.evaluate_hop(qed, pol_list)
+
             if (self.l_hop):
                 qed.get_data(self.pol, base_dir, pol_list, self.dt, self.istep, calc_force_only=True)
 
@@ -264,6 +265,7 @@ class SHXF(MQC_QED):
             self.hop_prob(qed)
             self.hop_check(pol_list)
             self.evaluate_hop(qed, pol_list)
+
             if (self.l_hop):
                 qed.get_data(self.pol, base_dir, pol_list, self.dt, istep, calc_force_only=True)
 


### PR DESCRIPTION
Now, NACME (not PNACME) is written when the verbosity is set to 1 (or higher value) in polariton dynamics